### PR TITLE
Refactored instantiation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "socket-server-mocker"
 description = "Mock socket server in Rust, for testing various network clients."
 authors = ["Thomas Prévost"]
-version = "0.0.5"
+version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/thomasarmel/socket-server-mocker"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! use socket_server_mocker::tcp_server_mocker::TcpServerMocker;
 //!
 //! // Mock HTTP server on a random free port
-//! let http_server_mocker = TcpServerMocker::new(0).unwrap();
+//! let http_server_mocker = TcpServerMocker::new().unwrap();
 //!
 //! http_server_mocker.add_mock_instructions(&[
 //!   // Wait for a HTTP GET request
@@ -29,7 +29,7 @@
 //! let response = client
 //!   .get(format!(
 //!     "http://localhost:{}/",
-//!     http_server_mocker.listening_port()
+//!     http_server_mocker.port()
 //!     ))
 //!   .send()
 //!   .unwrap();
@@ -43,7 +43,7 @@
 //! assert_eq!(
 //!   format!(
 //!     "GET / HTTP/1.1\r\naccept: */*\r\nhost: localhost:{}\r\n\r\n",
-//!     http_server_mocker.listening_port()
+//!     http_server_mocker.port()
 //!     ),
 //!     from_utf8(&*http_server_mocker.pop_received_message().unwrap()).unwrap()
 //!   );

--- a/src/server_mocker/mod.rs
+++ b/src/server_mocker/mod.rs
@@ -25,29 +25,12 @@ pub trait ServerMocker {
     /// Timeout if no more instruction is available and [`ServerMockerInstruction::StopExchange`] hasn't been sent
     const DEFAULT_THREAD_RECEIVER_TIMEOUT_MS: u64 = 100;
 
-    /// Creates a new server mocker
-    ///
-    /// # Arguments
-    /// port - the port to listen on, should be the same as the port the application you want to test uses to connect to the server
-    ///
-    /// Will listen on the local interface, port should not be used by another listening application
-    ///
-    /// Note that only 1 client will be able to connect to the server in case you use TCP, and the messages that the server send back to the client will be sent to the last client that sent to the server.
-    ///
-    /// If port is set to 0, the OS will choose a free port. Then you can get the port with [`Self::listening_port`]
-    ///
-    /// # Panics
-    /// Will panic in case of error with thread channel
-    fn new(port: u16) -> Result<Self, ServerMockerError>
-    where
-        Self: Sized;
-
     /// Returns the port on which the mock server is listening
     ///
     /// Listen only on local interface
     ///
     /// Port should not be used by another listening process
-    fn listening_port(&self) -> u16;
+    fn port(&self) -> u16;
 
     /// Adds a list of instructions to the server mocker
     ///

--- a/tests/dns_mock.rs
+++ b/tests/dns_mock.rs
@@ -11,7 +11,7 @@ use trust_dns_client::udp::UdpClientConnection;
 
 #[test]
 fn test_dns_mock() {
-    let dns_server_mocker = UdpServerMocker::new(0).unwrap();
+    let dns_server_mocker = UdpServerMocker::new().unwrap();
 
     dns_server_mocker
         .add_mock_instructions(&[
@@ -137,7 +137,7 @@ fn test_dns_mock() {
         ])
         .unwrap();
 
-    let address = format!("127.0.0.1:{}", dns_server_mocker.listening_port())
+    let address = format!("127.0.0.1:{}", dns_server_mocker.port())
         .parse()
         .unwrap();
     let conn = UdpClientConnection::new(address).unwrap();

--- a/tests/http_reqwest_api_mock.rs
+++ b/tests/http_reqwest_api_mock.rs
@@ -7,7 +7,7 @@ use socket_server_mocker::tcp_server_mocker::TcpServerMocker;
 #[test]
 fn http_get() {
     // Mock HTTP server on a random free port
-    let http_server_mocker = TcpServerMocker::new(0).unwrap();
+    let http_server_mocker = TcpServerMocker::new().unwrap();
 
     http_server_mocker.add_mock_instructions(&[
         // Wait for a HTTP GET request
@@ -24,7 +24,7 @@ fn http_get() {
     let response = client
         .get(format!(
             "http://localhost:{}/",
-            http_server_mocker.listening_port()
+            http_server_mocker.port()
         ))
         .send()
         .unwrap();
@@ -38,7 +38,7 @@ fn http_get() {
     assert_eq!(
         format!(
             "GET / HTTP/1.1\r\naccept: */*\r\nhost: localhost:{}\r\n\r\n",
-            http_server_mocker.listening_port()
+            http_server_mocker.port()
         ),
         std::str::from_utf8(&http_server_mocker.pop_received_message().unwrap()).unwrap()
     );

--- a/tests/postgres_mock.rs
+++ b/tests/postgres_mock.rs
@@ -17,7 +17,7 @@ use socket_server_mocker::tcp_server_mocker::TcpServerMocker;
 #[test]
 fn postgres_insert_mock() {
     // Mock PostgreSQL server on a port 54321 (default PostgresSQL port is 5432)
-    let postgres_server_mocker = TcpServerMocker::new(54321).unwrap();
+    let postgres_server_mocker = TcpServerMocker::new_with_port(54321).unwrap();
 
     // Add mock binary messages corresponding to client connection and authentication
     postgres_server_mocker
@@ -116,7 +116,7 @@ fn postgres_insert_mock() {
 #[test]
 fn postgres_select_mock() {
     // Mock PostgreSQL server on a random free port (default PostgresSQL port is 5432)
-    let postgres_server_mocker = TcpServerMocker::new(0).unwrap();
+    let postgres_server_mocker = TcpServerMocker::new().unwrap();
 
     // Add mock binary messages corresponding to client connection and authentication
     postgres_server_mocker
@@ -165,7 +165,7 @@ fn postgres_select_mock() {
     let mut client = Client::connect(
         &format!(
             "host=localhost user=admin password=password dbname=mockeddatabase port={}",
-            postgres_server_mocker.listening_port()
+            postgres_server_mocker.port()
         ),
         NoTls,
     )

--- a/tests/simple_receiving_tcp_message.rs
+++ b/tests/simple_receiving_tcp_message.rs
@@ -9,7 +9,7 @@ use std::net::TcpStream;
 
 #[test]
 fn simple_receiving_message_test() {
-    let tcp_server_mocker = TcpServerMocker::new(1234).unwrap();
+    let tcp_server_mocker = TcpServerMocker::new_with_port(1234).unwrap();
     let mut client = TcpStream::connect("127.0.0.1:1234").unwrap();
 
     tcp_server_mocker

--- a/tests/simple_sending_tcp_message.rs
+++ b/tests/simple_sending_tcp_message.rs
@@ -7,8 +7,8 @@ use std::net::TcpStream;
 #[test]
 fn simple_sending_message_test_random_port() {
     // Use random free port
-    let tcp_server_mocker = TcpServerMocker::new(0).unwrap();
-    let mock_port = tcp_server_mocker.listening_port();
+    let tcp_server_mocker = TcpServerMocker::new().unwrap();
+    let mock_port = tcp_server_mocker.port();
 
     // Connect to the mocked server
     let mut client = TcpStream::connect(format!("127.0.0.1:{mock_port}")).unwrap();

--- a/tests/simple_tcp.rs
+++ b/tests/simple_tcp.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 #[test]
 fn test_simple_tcp() {
     // Mock a TCP server listening on port 35642. Note that the mock will only listen on the local interface.
-    let tcp_server_mocker = TcpServerMocker::new(35642).unwrap();
+    let tcp_server_mocker = TcpServerMocker::new_with_port(35642).unwrap();
 
     // Create the TCP client to test
     let mut client = TcpStream::connect("127.0.0.1:35642").unwrap();
@@ -96,9 +96,9 @@ fn test_simple_tcp() {
 #[test]
 fn test_try_listen_twice_on_same_port() {
     // First TcpServerMocker will listen on a random free port
-    let tcp_server_mocker = TcpServerMocker::new(0).unwrap();
+    let tcp_server_mocker = TcpServerMocker::new().unwrap();
     // Second TcpServerMocker will try to listen on the same port
-    let tcp_server_mocker2 = TcpServerMocker::new(tcp_server_mocker.listening_port());
+    let tcp_server_mocker2 = TcpServerMocker::new_with_port(tcp_server_mocker.port());
     // The second TcpServerMocker should fail to listen on the same port
     assert!(tcp_server_mocker2.is_err());
 }
@@ -106,11 +106,11 @@ fn test_try_listen_twice_on_same_port() {
 #[test]
 fn test_receive_timeout() {
     // Mock a TCP server listening on a random free port
-    let tcp_server_mocker = TcpServerMocker::new(0).unwrap();
+    let tcp_server_mocker = TcpServerMocker::new().unwrap();
 
     // Create the TCP client to test
     let _client =
-        TcpStream::connect(format!("127.0.0.1:{}", tcp_server_mocker.listening_port())).unwrap();
+        TcpStream::connect(format!("127.0.0.1:{}", tcp_server_mocker.port())).unwrap();
 
     // Mocked server behavior
     tcp_server_mocker

--- a/tests/simple_udp.rs
+++ b/tests/simple_udp.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 #[test]
 fn test_simple_udp() {
     // Mock a UDP server listening on port 35642. Note that the mock will only listen on the local interface.
-    let udp_server_mocker = udp_server_mocker::UdpServerMocker::new(35642).unwrap();
+    let udp_server_mocker = udp_server_mocker::UdpServerMocker::new_with_port(35642).unwrap();
 
     // Create the UDP client to test
     let client_socket = UdpSocket::bind("127.0.0.1:34254").unwrap();
@@ -78,9 +78,9 @@ fn test_simple_udp() {
 #[test]
 fn test_try_listen_twice_on_same_port() {
     // First UdpServerMocker will listen on a random free port
-    let udp_server_mocker = UdpServerMocker::new(0).unwrap();
+    let udp_server_mocker = UdpServerMocker::new().unwrap();
     // Second UdpServerMocker will try to listen on the same port
-    let udp_server_mocker2 = UdpServerMocker::new(udp_server_mocker.listening_port());
+    let udp_server_mocker2 = UdpServerMocker::new_with_port(udp_server_mocker.port());
     // The second UdpServerMocker should fail to listen on the same port
     assert!(udp_server_mocker2.is_err());
 }
@@ -88,7 +88,7 @@ fn test_try_listen_twice_on_same_port() {
 #[test]
 fn test_try_receive_before_send() {
     // Mock a UDP server listening on random port
-    let udp_server_mocker = udp_server_mocker::UdpServerMocker::new(0).unwrap();
+    let udp_server_mocker = udp_server_mocker::UdpServerMocker::new().unwrap();
 
     // Mocked server behavior
     udp_server_mocker
@@ -119,7 +119,7 @@ fn test_try_receive_before_send() {
 #[test]
 fn test_receive_timeout() {
     // Mock a UDP server listening on a random free port
-    let udp_server_mocker = udp_server_mocker::UdpServerMocker::new(0).unwrap();
+    let udp_server_mocker = udp_server_mocker::UdpServerMocker::new().unwrap();
 
     // Mocked server behavior
     udp_server_mocker

--- a/tests/smtp_mock.rs
+++ b/tests/smtp_mock.rs
@@ -9,7 +9,7 @@ use socket_server_mocker::tcp_server_mocker::TcpServerMocker;
 #[test]
 fn test_smtp_mock() {
     // Create a SMTP TCP server mocker listening on port 2525 (SMTP default port is 25)
-    let smtp_server_mocker = TcpServerMocker::new(2525).unwrap();
+    let smtp_server_mocker = TcpServerMocker::new_with_port(2525).unwrap();
 
     // Mocked server behavior
     smtp_server_mocker.add_mock_instructions(&[


### PR DESCRIPTION
There is no point in having `new()` as part of a trait - unless the trait itself knows how to instantiate all variants of the class based on the params, but even then it should be a standalone function.

Instead, now both TCP and UDP have their own `new()` and `new_with_port(u16)`. Note that this is more in line with `mockito` design, except that there `with_port` has been deprecated in favor of `with_opts(ServerOpts)` -- which I think is too early. Eventually it may also need to be deprecated.

As part of the refactoring, renamed `listening_port` to `port`, and bumped minor version to indicate breaking API changes.  In a separate PR i will propose some CI changes to verify this automatically.