### PR TITLE
Use SocketAddr and `thiserror` errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/thomasarmel/socket-server-mocker"
 categories = ["network-programming", "development-tools::testing"]
 
 [dependencies]
+thiserror = "1.0.64"
 
 [dev-dependencies]
 reqwest = { version = "0.12.7", features = ["blocking"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("../README.md")]
-
 #![forbid(unsafe_code, unused_must_use)]
-#![forbid(
+#![warn(
     missing_docs,
     unreachable_pub,
     unused_import_braces,

--- a/src/server_mocker/mod.rs
+++ b/src/server_mocker/mod.rs
@@ -23,12 +23,17 @@ pub trait ServerMocker {
     /// Timeout if no more instruction is available and [`Instruction::StopExchange`] hasn't been sent
     const DEFAULT_THREAD_RECEIVER_TIMEOUT_MS: u64 = 100;
 
+    /// Returns the socket address on which the mock server is listening
+    fn socket_address(&self) -> std::net::SocketAddr;
+
     /// Returns the port on which the mock server is listening
     ///
     /// Listen only on local interface
     ///
     /// Port should not be used by another listening process
-    fn port(&self) -> u16;
+    fn port(&self) -> u16 {
+        self.socket_address().port()
+    }
 
     /// Adds a slice of instructions to the server mocker
     ///

--- a/src/server_mocker/server_mocker_error.rs
+++ b/src/server_mocker/server_mocker_error.rs
@@ -6,73 +6,64 @@
 //!
 //! If so, errors can be retrieved with [`ServerMocker::pop_server_error`](crate::server_mocker::ServerMocker::pop_server_error) method.
 
-use std::error::Error;
-use std::fmt::{Display, Formatter};
-
-/// Represents the fatalities of a server mocker error.
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum ServerMockerErrorFatality {
-    /// The error is fatal, the server mocker will stop.
-    Fatal,
-    /// The error is not fatal, the server mocker will continue.
-    NonFatal,
-}
-
-impl ServerMockerErrorFatality {
-    /// Returns true if the error is fatal, false otherwise.
-    pub fn is_fatal(&self) -> bool {
-        match self {
-            Self::Fatal => true,
-            Self::NonFatal => false,
-        }
-    }
-}
-
-/// Will display "Fatal" or "Non-fatal" depending on the error fatality.
-impl Display for ServerMockerErrorFatality {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Fatal => write!(f, "Fatal"),
-            Self::NonFatal => write!(f, "Non fatal"),
-        }
-    }
-}
+use crate::server_mocker_instruction::Instruction;
+use std::io;
+use std::net::SocketAddr;
+use std::sync::mpsc::SendError;
 
 /// Represents an error raised by a server mocker.
 ///
 /// The error is raised directly during call to [`ServerMocker`](crate::server_mocker::ServerMocker) methods, or when the server mocker is running asynchronously and an error occurs.
 ///
 /// If so, errors can be retrieved with [`ServerMocker::pop_server_error`](crate::server_mocker::ServerMocker::pop_server_error) method.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ServerMockerError {
-    /// The error message.
-    pub message: String,
-    /// The error [fatality](ServerMockerErrorFatality) - fatal if the mocked server stopped.
-    pub fatality: ServerMockerErrorFatality,
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum ServerMockerError {
+    #[error("{}: Failed to bind TCP listener on port {0}: {1}", self.fatal_str())]
+    UnableToBindListener(u16, io::Error),
+    #[error("{}: Failed to get local address of a listener: {0}", self.fatal_str())]
+    UnableToGetLocalAddress(io::Error),
+    #[error("{}: Failed to accept incoming connection on {0}: {1}", self.fatal_str())]
+    UnableToAcceptConnection(SocketAddr, io::Error),
+    #[error("{}: Failed to send instructions list to TCP server mocker: {0}", self.fatal_str())]
+    UnableToSendInstructions(SendError<Vec<Instruction>>),
+    #[error("{}: Failed to set read timeout on TCP stream: {0}", self.fatal_str())]
+    UnableToSetReadTimeout(io::Error),
+    #[error("{}: Failed to read from TCP stream: {0}", self.fatal_str())]
+    UnableToReadTcpStream(io::Error),
+    #[error("{}: Failed to write to TCP stream: {0}", self.fatal_str())]
+    UnableToWriteTcpStream(io::Error),
+    #[error("{}: Failed to receive message from client: {0}", self.fatal_str())]
+    UnableToReadUdpStream(io::Error),
+    #[error("{}: SendMessage instruction received before a ReceiveMessage", self.fatal_str())]
+    GotSendMessageBeforeReceiveMessage,
+    #[error("{}: Failed to send message to client: {0}", self.fatal_str())]
+    FailedToSendUdpMessage(io::Error),
 }
 
 impl ServerMockerError {
-    pub(crate) fn new(message: &str, fatality: ServerMockerErrorFatality) -> Self {
-        Self {
-            message: message.to_string(),
-            fatality,
+    /// Indicate if this is a fatal error
+    pub fn is_fatal(&self) -> bool {
+        match self {
+            ServerMockerError::UnableToBindListener(_, _)
+            | ServerMockerError::UnableToGetLocalAddress(_)
+            | ServerMockerError::UnableToAcceptConnection(_, _)
+            | ServerMockerError::UnableToSetReadTimeout(_) => true,
+
+            ServerMockerError::UnableToSendInstructions(_)
+            | ServerMockerError::UnableToReadTcpStream(_)
+            | ServerMockerError::UnableToWriteTcpStream(_)
+            | ServerMockerError::UnableToReadUdpStream(_)
+            | ServerMockerError::GotSendMessageBeforeReceiveMessage
+            | ServerMockerError::FailedToSendUdpMessage(_) => false,
         }
     }
 
-    /// Returns true if the error is fatal, false otherwise.
-    pub fn is_fatal(&self) -> bool {
-        self.fatality.is_fatal()
+    fn fatal_str(&self) -> &'static str {
+        if self.is_fatal() {
+            "Fatal"
+        } else {
+            "Non fatal"
+        }
     }
 }
-
-/// Will display:
-///
-/// "{Fatal | Non fatal}: {error message}"
-impl Display for ServerMockerError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: {}", self.fatality, self.message)
-    }
-}
-
-/// Ensure that `std::error::Error` is implemented for `ServerMockerError`
-impl Error for ServerMockerError {}

--- a/src/server_mocker/tcp_server_mocker.rs
+++ b/src/server_mocker/tcp_server_mocker.rs
@@ -3,13 +3,21 @@
 //! Mock a TCP server for testing application that connect to external TCP server.
 
 use crate::server_mocker::ServerMocker;
-use crate::server_mocker_error::{ServerMockerError, ServerMockerErrorFatality};
+use crate::server_mocker_error::ServerMockerError;
+use crate::server_mocker_error::ServerMockerError::{
+    UnableToAcceptConnection, UnableToBindListener, UnableToGetLocalAddress, UnableToReadTcpStream,
+    UnableToSendInstructions, UnableToSetReadTimeout, UnableToWriteTcpStream,
+};
+use crate::server_mocker_instruction::Instruction::{
+    ReceiveMessageWithMaxSize, SendMessage, SendMessageDependingOnLastReceivedMessage,
+};
 use crate::server_mocker_instruction::{BinaryMessage, Instruction};
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc;
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
+use std::time::Duration;
 
 /// A TCP server mocker
 ///
@@ -18,9 +26,9 @@ use std::thread;
 /// Only 1 client can be connected to the mocked server. When the connection is closed, the mocked server will stop.
 pub struct TcpServerMocker {
     socket_addr: SocketAddr,
-    instructions_sender: Sender<Vec<Instruction>>,
-    message_receiver: Receiver<BinaryMessage>,
-    error_receiver: Receiver<ServerMockerError>,
+    instruction_tx: Sender<Vec<Instruction>>,
+    message_rx: Receiver<BinaryMessage>,
+    error_rx: Receiver<ServerMockerError>,
 }
 
 impl TcpServerMocker {
@@ -37,47 +45,33 @@ impl TcpServerMocker {
             Sender<Vec<Instruction>>,
             Receiver<Vec<Instruction>>,
         ) = mpsc::channel();
-        let (message_tx, message_rx): (Sender<BinaryMessage>, Receiver<BinaryMessage>) =
-            mpsc::channel();
-        let (error_tx, error_rx): (Sender<ServerMockerError>, Receiver<ServerMockerError>) =
-            mpsc::channel();
+        let (message_tx, message_rx) = mpsc::channel();
+        let (error_tx, error_rx) = mpsc::channel();
 
         let addr: SocketAddr = ([127, 0, 0, 1], port).into();
-        let tcp_listener = TcpListener::bind(addr).map_err(|e| {
-            ServerMockerError::new(
-                &format!("Failed to bind TCP listener on port {port}: {e}"),
-                ServerMockerErrorFatality::Fatal,
-            )
-        })?;
+        let listener = TcpListener::bind(addr).map_err(|e| UnableToBindListener(port, e))?;
 
-        let socket_addr = tcp_listener.local_addr().map_err(|e| {
-            ServerMockerError::new(
-                &format!("Failed to get local address of TCP listener: {e}"),
-                ServerMockerErrorFatality::Fatal,
-            )
-        })?;
+        let socket_addr = listener
+            .local_addr()
+            .map_err(|e| UnableToGetLocalAddress(e))?;
 
         thread::spawn(move || {
-            let tcp_stream = match tcp_listener.accept() {
-                Ok(incoming_client) => incoming_client.0,
-                Err(_) => {
-                    error_tx
-                        .send(ServerMockerError::new(
-                            &format!("Failed to accept incoming client on port {port}"),
-                            ServerMockerErrorFatality::Fatal,
-                        ))
-                        .unwrap();
-                    return;
-                }
-            }; // We need to manage only 1 client
-            Self::handle_connection(tcp_stream, instruction_rx, message_tx, error_tx);
+            let Ok(tcp_stream) = listener.accept().map_err(|e| {
+                error_tx
+                    .send(UnableToAcceptConnection(socket_addr, e))
+                    .unwrap();
+            }) else {
+                return;
+            };
+            // We need to manage only 1 client
+            Self::handle_connection(tcp_stream.0, instruction_rx, message_tx, error_tx);
         });
 
         Ok(Self {
             socket_addr,
-            instructions_sender: instruction_tx,
-            message_receiver: message_rx,
-            error_receiver: error_rx,
+            instruction_tx,
+            message_rx,
+            error_rx,
         })
     }
 }
@@ -116,27 +110,20 @@ impl ServerMocker for TcpServerMocker {
         &self,
         instructions: Vec<Instruction>,
     ) -> Result<(), ServerMockerError> {
-        self.instructions_sender.send(instructions).map_err(|e| {
-            ServerMockerError::new(
-                &format!("Failed to send instructions list to TCP server mocker: {e}"),
-                ServerMockerErrorFatality::NonFatal,
-            )
-        })
+        self.instruction_tx
+            .send(instructions)
+            .map_err(|e| UnableToSendInstructions(e))
     }
 
     fn pop_received_message(&self) -> Option<BinaryMessage> {
-        self.message_receiver
-            .recv_timeout(std::time::Duration::from_millis(
-                Self::DEFAULT_NET_TIMEOUT_MS,
-            ))
+        self.message_rx
+            .recv_timeout(Duration::from_millis(Self::DEFAULT_NET_TIMEOUT_MS))
             .ok()
     }
 
     fn pop_server_error(&self) -> Option<ServerMockerError> {
-        self.error_receiver
-            .recv_timeout(std::time::Duration::from_millis(
-                Self::DEFAULT_NET_TIMEOUT_MS,
-            ))
+        self.error_rx
+            .recv_timeout(Duration::from_millis(Self::DEFAULT_NET_TIMEOUT_MS))
             .ok()
     }
 }
@@ -147,74 +134,59 @@ impl TcpServerMocker {
     const DEFAULT_SOCKET_READER_BUFFER_SIZE: usize = 1024;
 
     fn handle_connection(
-        mut tcp_stream: TcpStream,
+        mut connection: TcpStream,
         instructions_receiver: Receiver<Vec<Instruction>>,
         message_sender: Sender<BinaryMessage>,
         error_sender: Sender<ServerMockerError>,
     ) {
-        if tcp_stream
-            .set_read_timeout(Some(std::time::Duration::from_millis(
-                Self::DEFAULT_NET_TIMEOUT_MS,
-            )))
-            .is_err()
-        {
-            error_sender
-                .send(ServerMockerError::new(
-                    "Failed to set read timeout on TCP stream",
-                    ServerMockerErrorFatality::Fatal,
-                ))
-                .unwrap();
+        let timeout = Some(Duration::from_millis(Self::DEFAULT_NET_TIMEOUT_MS));
+        if let Err(e) = connection.set_read_timeout(timeout) {
+            error_sender.send(UnableToSetReadTimeout(e)).unwrap();
             return;
         }
         let mut last_received_message: Option<BinaryMessage> = None;
 
         // Timeout: if no more instruction is available and StopExchange hasn't been sent
         // Stop server if no more instruction is available and StopExchange hasn't been sent
-        while let Ok(instructions_list) = instructions_receiver.recv_timeout(
-            std::time::Duration::from_millis(Self::DEFAULT_THREAD_RECEIVER_TIMEOUT_MS),
-        ) {
+        while let Ok(instructions_list) = instructions_receiver.recv_timeout(Duration::from_millis(
+            Self::DEFAULT_THREAD_RECEIVER_TIMEOUT_MS,
+        )) {
             for instruction in instructions_list {
                 match instruction {
-                    Instruction::SendMessage(binary_message) => {
-                        if let Err(e) = Self::send_packet(&mut tcp_stream, &binary_message) {
+                    SendMessage(binary_message) => {
+                        if let Err(e) = Self::send_packet(&mut connection, &binary_message) {
                             error_sender.send(e).unwrap();
                         }
                     }
-                    Instruction::SendMessageDependingOnLastReceivedMessage(
-                        sent_message_calculator,
-                    ) => {
+                    SendMessageDependingOnLastReceivedMessage(sent_message_calculator) => {
                         // Call the closure to get the message to send
                         let message_to_send =
                             sent_message_calculator(last_received_message.clone());
                         // Send the message or skip if the closure returned None
                         if let Some(message_to_send) = message_to_send {
-                            if let Err(e) = Self::send_packet(&mut tcp_stream, &message_to_send) {
+                            if let Err(e) = Self::send_packet(&mut connection, &message_to_send) {
                                 error_sender.send(e).unwrap();
                             }
                         }
                     }
                     Instruction::ReceiveMessage => {
-                        let whole_received_packet = match Self::read_packet(&mut tcp_stream) {
-                            Ok(whole_received_packet) => whole_received_packet,
-                            Err(e) => {
-                                error_sender.send(e).unwrap();
-                                continue;
+                        match Self::read_packet(&mut connection) {
+                            Ok(whole_received_packet) => {
+                                last_received_message = Some(whole_received_packet.clone());
+                                message_sender.send(whole_received_packet).unwrap();
                             }
+                            Err(e) => error_sender.send(e).unwrap(),
                         };
-                        last_received_message = Some(whole_received_packet.clone());
-                        message_sender.send(whole_received_packet).unwrap();
                     }
-                    Instruction::ReceiveMessageWithMaxSize(max_message_size) => {
-                        let mut whole_received_packet = match Self::read_packet(&mut tcp_stream) {
-                            Ok(whole_received_packet) => whole_received_packet,
-                            Err(e) => {
-                                error_sender.send(e).unwrap();
-                                continue;
+                    ReceiveMessageWithMaxSize(max_message_size) => {
+                        match Self::read_packet(&mut connection) {
+                            Ok(mut whole_received_packet) => {
+                                whole_received_packet.truncate(max_message_size);
+                                last_received_message = Some(whole_received_packet.clone());
+                                message_sender.send(whole_received_packet).unwrap();
                             }
+                            Err(e) => error_sender.send(e).unwrap(),
                         };
-                        whole_received_packet.truncate(max_message_size);
-                        last_received_message = Some(whole_received_packet.clone());
-                        message_sender.send(whole_received_packet).unwrap();
                     }
                     Instruction::StopExchange => {
                         return;
@@ -230,12 +202,9 @@ impl TcpServerMocker {
         let mut buffer = [0; Self::DEFAULT_SOCKET_READER_BUFFER_SIZE];
 
         loop {
-            let bytes_read = tcp_stream.read(&mut buffer).map_err(|e| {
-                ServerMockerError::new(
-                    &format!("Failed to read from TCP stream: {e}"),
-                    ServerMockerErrorFatality::NonFatal,
-                )
-            })?;
+            let bytes_read = tcp_stream
+                .read(&mut buffer)
+                .map_err(|e| UnableToReadTcpStream(e))?;
             whole_received_packet.extend_from_slice(&buffer[..bytes_read]);
             if bytes_read < Self::DEFAULT_SOCKET_READER_BUFFER_SIZE {
                 break;
@@ -248,11 +217,8 @@ impl TcpServerMocker {
         tcp_stream: &mut TcpStream,
         packet: &BinaryMessage,
     ) -> Result<(), ServerMockerError> {
-        tcp_stream.write_all(packet).map_err(|e| {
-            ServerMockerError::new(
-                &format!("Failed to write to TCP stream: {e}"),
-                ServerMockerErrorFatality::NonFatal,
-            )
-        })
+        tcp_stream
+            .write_all(packet)
+            .map_err(|e| UnableToWriteTcpStream(e))
     }
 }

--- a/src/server_mocker/udp_server_mocker.rs
+++ b/src/server_mocker/udp_server_mocker.rs
@@ -3,7 +3,12 @@
 //! Mock a UDP server for testing application that connect to external UDP server.
 
 use crate::server_mocker::ServerMocker;
-use crate::server_mocker_error::{ServerMockerError, ServerMockerErrorFatality};
+use crate::server_mocker_error::ServerMockerError;
+use crate::server_mocker_error::ServerMockerError::{
+    FailedToSendUdpMessage, GotSendMessageBeforeReceiveMessage, UnableToBindListener,
+    UnableToGetLocalAddress, UnableToReadUdpStream, UnableToSendInstructions,
+    UnableToSetReadTimeout,
+};
 use crate::server_mocker_instruction::Instruction::{
     ReceiveMessageWithMaxSize, SendMessage, SendMessageDependingOnLastReceivedMessage,
 };
@@ -12,6 +17,7 @@ use std::net::{SocketAddr, UdpSocket};
 use std::sync::mpsc;
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
+use std::time::Duration;
 
 /// A UDP server mocker
 ///
@@ -22,9 +28,9 @@ use std::thread;
 /// The server will also stop in case no more instructions are available.
 pub struct UdpServerMocker {
     socket_addr: SocketAddr,
-    instructions_sender: Sender<Vec<Instruction>>,
-    message_receiver: Receiver<BinaryMessage>,
-    error_receiver: Receiver<ServerMockerError>,
+    instruction_tx: Sender<Vec<Instruction>>,
+    message_rx: Receiver<BinaryMessage>,
+    error_rx: Receiver<ServerMockerError>,
 }
 
 impl UdpServerMocker {
@@ -41,35 +47,25 @@ impl UdpServerMocker {
             Sender<Vec<Instruction>>,
             Receiver<Vec<Instruction>>,
         ) = mpsc::channel();
-        let (message_tx, message_rx): (Sender<BinaryMessage>, Receiver<BinaryMessage>) =
-            mpsc::channel();
-        let (error_tx, error_rx): (Sender<ServerMockerError>, Receiver<ServerMockerError>) =
-            mpsc::channel();
+        let (message_tx, message_rx) = mpsc::channel();
+        let (error_tx, error_rx) = mpsc::channel();
 
         let addr: SocketAddr = ([127, 0, 0, 1], port).into();
-        let socket = UdpSocket::bind(addr).map_err(|e| {
-            ServerMockerError::new(
-                &format!("Failed to create UDP socket on port {port}: {e}"),
-                ServerMockerErrorFatality::Fatal,
-            )
-        })?;
+        let listener = UdpSocket::bind(addr).map_err(|e| UnableToBindListener(port, e))?;
 
-        let socket_addr = socket.local_addr().map_err(|e| {
-            ServerMockerError::new(
-                &format!("Failed to get local port of UDP socket: {e}"),
-                ServerMockerErrorFatality::Fatal,
-            )
-        })?;
+        let socket_addr = listener
+            .local_addr()
+            .map_err(|e| UnableToGetLocalAddress(e))?;
 
         thread::spawn(move || {
-            Self::handle_dgram_stream(socket, instruction_rx, message_tx, error_tx);
+            Self::handle_dgram_stream(listener, instruction_rx, message_tx, error_tx);
         });
 
         Ok(Self {
             socket_addr,
-            instructions_sender: instruction_tx,
-            message_receiver: message_rx,
-            error_receiver: error_rx,
+            instruction_tx,
+            message_rx,
+            error_rx,
         })
     }
 }
@@ -110,27 +106,20 @@ impl ServerMocker for UdpServerMocker {
         &self,
         instructions: Vec<Instruction>,
     ) -> Result<(), ServerMockerError> {
-        self.instructions_sender.send(instructions).map_err(|e| {
-            ServerMockerError::new(
-                &format!("Failed to send instructions to UDP server mocker: {e}"),
-                ServerMockerErrorFatality::NonFatal,
-            )
-        })
+        self.instruction_tx
+            .send(instructions)
+            .map_err(|e| UnableToSendInstructions(e))
     }
 
     fn pop_received_message(&self) -> Option<BinaryMessage> {
-        self.message_receiver
-            .recv_timeout(std::time::Duration::from_millis(
-                Self::DEFAULT_NET_TIMEOUT_MS,
-            ))
+        self.message_rx
+            .recv_timeout(Duration::from_millis(Self::DEFAULT_NET_TIMEOUT_MS))
             .ok()
     }
 
     fn pop_server_error(&self) -> Option<ServerMockerError> {
-        self.error_receiver
-            .recv_timeout(std::time::Duration::from_millis(
-                Self::DEFAULT_NET_TIMEOUT_MS,
-            ))
+        self.error_rx
+            .recv_timeout(Duration::from_millis(Self::DEFAULT_NET_TIMEOUT_MS))
             .ok()
     }
 }
@@ -141,23 +130,14 @@ impl UdpServerMocker {
     const MAX_UDP_PACKET_SIZE: usize = 65507;
 
     fn handle_dgram_stream(
-        udp_socket: UdpSocket,
+        connection: UdpSocket,
         instructions_receiver: Receiver<Vec<Instruction>>,
         message_sender: Sender<BinaryMessage>,
         error_sender: Sender<ServerMockerError>,
     ) {
-        if udp_socket
-            .set_read_timeout(Some(std::time::Duration::from_millis(
-                Self::DEFAULT_NET_TIMEOUT_MS,
-            )))
-            .is_err()
-        {
-            error_sender
-                .send(ServerMockerError::new(
-                    "Failed to set read timeout on UDP socket",
-                    ServerMockerErrorFatality::Fatal,
-                ))
-                .unwrap();
+        let timeout = Some(Duration::from_millis(Self::DEFAULT_NET_TIMEOUT_MS));
+        if let Err(e) = connection.set_read_timeout(timeout) {
+            error_sender.send(UnableToSetReadTimeout(e)).unwrap();
             return;
         }
 
@@ -166,14 +146,14 @@ impl UdpServerMocker {
 
         // Timeout: if no more instruction is available and StopExchange hasn't been sent
         // Stop server if no more instruction is available and StopExchange hasn't been sent
-        while let Ok(instructions_list) = instructions_receiver.recv_timeout(
-            std::time::Duration::from_millis(Self::DEFAULT_THREAD_RECEIVER_TIMEOUT_MS),
-        ) {
+        while let Ok(instructions_list) = instructions_receiver.recv_timeout(Duration::from_millis(
+            Self::DEFAULT_THREAD_RECEIVER_TIMEOUT_MS,
+        )) {
             for instruction in instructions_list {
                 match instruction {
                     SendMessage(binary_message) => {
                         if let Err(e) = Self::send_packet_to_last_client(
-                            &udp_socket,
+                            &connection,
                             &binary_message,
                             &last_received_packed_with_addr,
                         ) {
@@ -189,7 +169,7 @@ impl UdpServerMocker {
                             });
                         if let Some(message_to_send) = message_to_send {
                             if let Err(e) = Self::send_packet_to_last_client(
-                                &udp_socket,
+                                &connection,
                                 &message_to_send,
                                 &last_received_packed_with_addr,
                             ) {
@@ -199,7 +179,7 @@ impl UdpServerMocker {
                     }
                     Instruction::ReceiveMessage => {
                         let received_packet_with_addr =
-                            match Self::receive_packet(&udp_socket, Self::MAX_UDP_PACKET_SIZE) {
+                            match Self::receive_packet(&connection, Self::MAX_UDP_PACKET_SIZE) {
                                 Ok(received) => received,
                                 Err(e) => {
                                     error_sender.send(e).unwrap();
@@ -214,20 +194,14 @@ impl UdpServerMocker {
                         message_sender.send(received_packet_with_addr.1).unwrap();
                     }
                     ReceiveMessageWithMaxSize(max_message_size) => {
-                        let received_packet_with_addr =
-                            match Self::receive_packet(&udp_socket, max_message_size) {
-                                Ok(received) => received,
-                                Err(e) => {
-                                    error_sender.send(e).unwrap();
-                                    continue;
-                                }
-                            };
-
-                        last_received_packed_with_addr = Some((
-                            received_packet_with_addr.0,
-                            received_packet_with_addr.1.clone(),
-                        ));
-                        message_sender.send(received_packet_with_addr.1).unwrap();
+                        match Self::receive_packet(&connection, max_message_size) {
+                            Ok(received) => {
+                                last_received_packed_with_addr =
+                                    Some((received.0, received.1.clone()));
+                                message_sender.send(received.1).unwrap();
+                            }
+                            Err(e) => error_sender.send(e).unwrap(),
+                        };
                     }
                     Instruction::StopExchange => {
                         return;
@@ -245,12 +219,7 @@ impl UdpServerMocker {
 
         let (bytes_read, packet_sender_addr) = udp_socket
             .recv_from(&mut whole_received_packet)
-            .map_err(|e| {
-                ServerMockerError::new(
-                    &format!("Failed to receive message from client: {e}"),
-                    ServerMockerErrorFatality::NonFatal,
-                )
-            })?;
+            .map_err(|e| UnableToReadUdpStream(e))?;
 
         // Remove the extra bytes
         whole_received_packet.truncate(bytes_read);
@@ -266,21 +235,14 @@ impl UdpServerMocker {
         // Last message received with the address of the client, used to send the response
         last_received_packed_with_addr
             .as_ref()
-            .ok_or(ServerMockerError::new(
-                "SendMessage instruction received before a ReceiveMessage",
-                ServerMockerErrorFatality::NonFatal,
-            ))?;
+            .ok_or(GotSendMessageBeforeReceiveMessage)?;
+
         udp_socket
             .send_to(
                 message_to_send,
                 last_received_packed_with_addr.as_ref().unwrap().0,
             )
-            .map_err(|e| {
-                ServerMockerError::new(
-                    &format!("Failed to send message to client: {e}"),
-                    ServerMockerErrorFatality::NonFatal,
-                )
-            })?;
+            .map_err(|e| FailedToSendUdpMessage(e))?;
         Ok(())
     }
 }

--- a/tests/simple_tcp.rs
+++ b/tests/simple_tcp.rs
@@ -1,5 +1,4 @@
 use socket_server_mocker::server_mocker::ServerMocker;
-use socket_server_mocker::server_mocker_error::ServerMockerErrorFatality;
 use socket_server_mocker::server_mocker_instruction::Instruction::{
     ReceiveMessage, ReceiveMessageWithMaxSize, SendMessage,
     SendMessageDependingOnLastReceivedMessage, StopExchange,
@@ -131,8 +130,5 @@ fn test_receive_timeout() {
     let tcp_server_error = tcp_server_mocker.pop_server_error();
     assert!(tcp_server_error.is_some());
     let tcp_server_error = tcp_server_error.unwrap();
-    assert_eq!(
-        ServerMockerErrorFatality::NonFatal,
-        tcp_server_error.fatality
-    );
+    assert!(!tcp_server_error.is_fatal());
 }

--- a/tests/simple_udp.rs
+++ b/tests/simple_udp.rs
@@ -1,5 +1,4 @@
 use socket_server_mocker::server_mocker::ServerMocker;
-use socket_server_mocker::server_mocker_error::ServerMockerErrorFatality;
 use socket_server_mocker::server_mocker_instruction::Instruction::{
     ReceiveMessageWithMaxSize, SendMessage, SendMessageDependingOnLastReceivedMessage,
 };
@@ -109,10 +108,7 @@ fn test_try_receive_before_send() {
         "Non fatal: SendMessage instruction received before a ReceiveMessage",
         mocked_server_error.to_string()
     );
-    assert_eq!(
-        ServerMockerErrorFatality::NonFatal,
-        mocked_server_error.fatality
-    );
+    assert!(!mocked_server_error.is_fatal());
 }
 
 #[test]
@@ -136,8 +132,5 @@ fn test_receive_timeout() {
     // Check that the mocked server has raised an error
     let mocked_server_error_received = udp_server_mocker.pop_server_error();
     assert!(mocked_server_error_received.is_some());
-    assert_eq!(
-        ServerMockerErrorFatality::NonFatal,
-        mocked_server_error_received.unwrap().fatality
-    );
+    assert!(!mocked_server_error_received.unwrap().is_fatal());
 }


### PR DESCRIPTION
* Socket addr is a more flexible way to store what the mock is bound to, and port can be extracted from that.
* Use `thiserror` to handle all the error reporting, including the `is_fatal()` stuff
* I made the code difference between tcp and udp minimal - this way we can eventually consolidate the two variants into one

P.S. a good rule of thumb I found useful for naming variables:  the smaller the scope of the variable, the shorter should be its name.