### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,18 +1,48 @@
 name: Rust
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  test:
+    name: Test
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
+      - uses: actions/checkout@v4
+      - name: Ensure this crate has not yet been published (on release)
+        if: github.event_name == 'release'
+        run: just check-if-published
+      - uses: Swatinem/rust-cache@v2
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      - run: just ci-test
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
+  msrv:
+    name: Test MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      - name: Read crate metadata
+        id: metadata
+        run: echo "rust-version=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.metadata.outputs.rust-version }}
+      - run: just ci-test-msrv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ name = "socket-server-mocker"
 description = "Mock socket server in Rust, for testing various network clients."
 authors = ["Thomas Prévost"]
 version = "0.2.0"
+rust-version = "1.74.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/thomasarmel/socket-server-mocker"
-# List of categories can be found at https://crates.io/category_slugs
 categories = ["network-programming", "development-tools::testing"]
 
 [dependencies]
@@ -17,3 +17,21 @@ reqwest = { version = "0.12.7", features = ["blocking"] }
 postgres = "0.19.9"
 trust-dns-client = "0.23.2"
 lettre = "0.11.9"
+
+[lints.rust]
+# Forbid unsafe code
+unsafe_code = "forbid"
+# The rest of the lints could be overriden in the code
+unused_must_use = "deny"
+missing_docs = "deny"
+unreachable_pub = "deny"
+unused_import_braces = "deny"
+unused_extern_crates = "deny"
+
+[lints.clippy]
+# TODO: uncomment these once all PRs are merged, and fix the code issues
+#pedantic = { level = "warn", priority = -1 }
+## Ideally this should be fixed, although some could be safely ignored
+#module_name_repetitions = "allow"
+#must_use_candidate = "allow"
+#missing_errors_doc = "allow"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# socket-server-mocker
+j # socket-server-mocker
+
+[![GitHub](https://img.shields.io/badge/github-thomasarmel/socket--server--mocker-8da0cb?logo=github)](https://github.com/thomasarmel/socket-server-mocker)
+[![crates.io version](https://img.shields.io/crates/v/socket-server-mocker.svg)](https://crates.io/crates/socket-server-mocker)
+[![docs.rs docs](https://docs.rs/socket-server-mocker/badge.svg)](https://docs.rs/socket-server-mocker)
+[![crates.io version](https://img.shields.io/crates/l/socket-server-mocker.svg)](https://github.com/thomasarmel/socket-server-mocker/blob/main/LICENSE)
+[![CI build](https://github.com/thomasarmel/socket-server-mocker/actions/workflows/rust.yml/badge.svg)](https://github.com/thomasarmel/socket-server-mocker/actions)
 
 _Mock socket server in Rust, for testing various network clients._
 
@@ -165,3 +171,10 @@ assert_eq!("hello2 from server", received_message);
 // Check that no error has been raised by the mocked server
 assert!(udp_server_mocker.pop_server_error().is_none());
 ```
+
+## Development
+
+* This project is easier to develop with [just](https://github.com/casey/just#readme), a modern alternative to `make`.
+  Install it with `cargo install just`.
+* To get a list of available commands, run `just`.
+* To run tests, use `just test`.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,68 @@
+#!/usr/bin/env just --justfile
+
+@_default:
+    just --list --unsorted
+
+# Clean all build artifacts
+clean:
+    cargo clean
+    rm -f Cargo.lock
+
+update:
+    cargo +nightly -Z unstable-options update --breaking
+    cargo update
+
+# Run cargo clippy
+clippy:
+    cargo clippy --all-targets -- -D warnings
+
+# Test code formatting
+test-fmt:
+    cargo fmt --all -- --check
+
+# Run cargo fmt
+fmt:
+    cargo +nightly fmt -- --config imports_granularity=Module,group_imports=StdExternalCrate
+
+# Build and open code documentation
+docs:
+    cargo doc --no-deps --open
+
+# Quick compile
+check:
+    RUSTFLAGS='-D warnings' cargo check --workspace --all-targets
+
+# Run all tests
+test:
+    cargo test
+
+# Test documentation
+test-doc:
+    cargo test --doc
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+
+rust-info:
+    rustc --version
+    cargo --version
+
+# Run all tests as expected by CI
+ci-test: rust-info test-fmt clippy check test test-doc
+
+# Run minimal subset of tests to ensure compatibility with MSRV
+ci-test-msrv: rust-info check test
+
+# Verify that the current version of the crate is not the same as the one published on crates.io
+check-if-published:
+    #!/usr/bin/env bash
+    LOCAL_VERSION="$(grep '^version =' Cargo.toml | sed -E 's/version = "([^"]*)".*/\1/')"
+    echo "Detected crate version:  $LOCAL_VERSION"
+    CRATE_NAME="$(grep '^name =' Cargo.toml | head -1 | sed -E 's/name = "(.*)"/\1/')"
+    echo "Detected crate name:     $CRATE_NAME"
+    PUBLISHED_VERSION="$(cargo search ${CRATE_NAME} | grep "^${CRATE_NAME} =" | sed -E 's/.* = "(.*)".*/\1/')"
+    echo "Published crate version: $PUBLISHED_VERSION"
+    if [ "$LOCAL_VERSION" = "$PUBLISHED_VERSION" ]; then
+        echo "ERROR: The current crate version has already been published."
+        exit 1
+    else
+        echo "The current crate version has not yet been published."
+    fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![forbid(unsafe_code, unused_must_use)]
-#![warn(
-    missing_docs,
-    unreachable_pub,
-    unused_import_braces,
-    unused_extern_crates
-)]
 
 //! # socket-server-mocker
 //!

--- a/src/server_mocker/tcp_server_mocker.rs
+++ b/src/server_mocker/tcp_server_mocker.rs
@@ -51,9 +51,7 @@ impl TcpServerMocker {
         let addr: SocketAddr = ([127, 0, 0, 1], port).into();
         let listener = TcpListener::bind(addr).map_err(|e| UnableToBindListener(port, e))?;
 
-        let socket_addr = listener
-            .local_addr()
-            .map_err(|e| UnableToGetLocalAddress(e))?;
+        let socket_addr = listener.local_addr().map_err(UnableToGetLocalAddress)?;
 
         thread::spawn(move || {
             let Ok(tcp_stream) = listener.accept().map_err(|e| {
@@ -112,7 +110,7 @@ impl ServerMocker for TcpServerMocker {
     ) -> Result<(), ServerMockerError> {
         self.instruction_tx
             .send(instructions)
-            .map_err(|e| UnableToSendInstructions(e))
+            .map_err(UnableToSendInstructions)
     }
 
     fn pop_received_message(&self) -> Option<BinaryMessage> {
@@ -204,7 +202,7 @@ impl TcpServerMocker {
         loop {
             let bytes_read = tcp_stream
                 .read(&mut buffer)
-                .map_err(|e| UnableToReadTcpStream(e))?;
+                .map_err(UnableToReadTcpStream)?;
             whole_received_packet.extend_from_slice(&buffer[..bytes_read]);
             if bytes_read < Self::DEFAULT_SOCKET_READER_BUFFER_SIZE {
                 break;
@@ -217,8 +215,6 @@ impl TcpServerMocker {
         tcp_stream: &mut TcpStream,
         packet: &BinaryMessage,
     ) -> Result<(), ServerMockerError> {
-        tcp_stream
-            .write_all(packet)
-            .map_err(|e| UnableToWriteTcpStream(e))
+        tcp_stream.write_all(packet).map_err(UnableToWriteTcpStream)
     }
 }

--- a/src/server_mocker/udp_server_mocker.rs
+++ b/src/server_mocker/udp_server_mocker.rs
@@ -53,9 +53,7 @@ impl UdpServerMocker {
         let addr: SocketAddr = ([127, 0, 0, 1], port).into();
         let listener = UdpSocket::bind(addr).map_err(|e| UnableToBindListener(port, e))?;
 
-        let socket_addr = listener
-            .local_addr()
-            .map_err(|e| UnableToGetLocalAddress(e))?;
+        let socket_addr = listener.local_addr().map_err(UnableToGetLocalAddress)?;
 
         thread::spawn(move || {
             Self::handle_dgram_stream(listener, instruction_rx, message_tx, error_tx);
@@ -108,7 +106,7 @@ impl ServerMocker for UdpServerMocker {
     ) -> Result<(), ServerMockerError> {
         self.instruction_tx
             .send(instructions)
-            .map_err(|e| UnableToSendInstructions(e))
+            .map_err(UnableToSendInstructions)
     }
 
     fn pop_received_message(&self) -> Option<BinaryMessage> {
@@ -219,7 +217,7 @@ impl UdpServerMocker {
 
         let (bytes_read, packet_sender_addr) = udp_socket
             .recv_from(&mut whole_received_packet)
-            .map_err(|e| UnableToReadUdpStream(e))?;
+            .map_err(UnableToReadUdpStream)?;
 
         // Remove the extra bytes
         whole_received_packet.truncate(bytes_read);
@@ -242,7 +240,7 @@ impl UdpServerMocker {
                 message_to_send,
                 last_received_packed_with_addr.as_ref().unwrap().0,
             )
-            .map_err(|e| FailedToSendUdpMessage(e))?;
+            .map_err(FailedToSendUdpMessage)?;
         Ok(())
     }
 }


### PR DESCRIPTION
* use comprehensive CI for both latest and MSRV versions
* set MSRV using `cargo msrv` command to find out the minimal working one
* cache rust artifacts between builds
* use `just` for all common commands so users don't need to know any flags, and CI would use the same commands
* add readme flags to indicate project status
* use proper `on ...` events -- good for open source projects to only build once, both for your own and fork contributions