### PR TITLE
Make all options configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "socket-server-mocker"
 description = "Mock socket server in Rust, for testing various network clients."
 authors = ["Thomas Prévost", "Yuri Astrakhan <YuriAstrakhan>@gmail.com"]
-version = "0.3.1"
+version = "0.4.0"
 rust-version = "1.74.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,8 +19,8 @@ use crate::Instruction;
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum ServerMockerError {
-    #[error("{}: Failed to bind TCP listener on port {0}: {1}", self.fatal_str())]
-    UnableToBindListener(u16, io::Error),
+    #[error("{}: Failed to bind TCP listener to {0}: {1}", self.fatal_str())]
+    UnableToBindListener(SocketAddr, io::Error),
     #[error("{}: Failed to get local address of a listener: {0}", self.fatal_str())]
     UnableToGetLocalAddress(io::Error),
     #[error("{}: Failed to accept incoming connection on {0}: {1}", self.fatal_str())]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@
 //! use socket_server_mocker::TcpServerMocker;
 //!
 //! // Mock HTTP server on a random free port
-//! let http_server_mocker = TcpServerMocker::new().unwrap();
+//! let server = TcpServerMocker::new().unwrap();
 //!
-//! http_server_mocker.add_mock_instructions(vec![
+//! server.add_mock_instructions(vec![
 //!   // Wait for an HTTP GET request
 //!   ReceiveMessage,
 //!   // Send an HTTP response
@@ -29,7 +29,7 @@
 //! let client = reqwest::blocking::Client::new();
 //! // Send an HTTP GET request to the mocked server
 //! let response = client
-//!   .get(format!("http://localhost:{}/", http_server_mocker.port()))
+//!   .get(format!("http://localhost:{}/", server.port()))
 //!   .send()
 //!   .unwrap();
 //!
@@ -42,13 +42,13 @@
 //! assert_eq!(
 //!   format!(
 //!     "GET / HTTP/1.1\r\naccept: */*\r\nhost: localhost:{}\r\n\r\n",
-//!     http_server_mocker.port()
+//!     server.port()
 //!     ),
-//!     from_utf8(&*http_server_mocker.pop_received_message().unwrap()).unwrap()
+//!     from_utf8(&*server.pop_received_message().unwrap()).unwrap()
 //!   );
 //!
 //! // Check that no error has been raised by the mocked server
-//! assert!(http_server_mocker.pop_server_error().is_none());
+//! assert!(server.pop_server_error().is_none());
 //! ```
 
 mod errors;
@@ -60,5 +60,5 @@ mod udp_server;
 pub use errors::ServerMockerError;
 pub use instructions::Instruction;
 pub use server_mocker::ServerMocker;
-pub use tcp_server::TcpServerMocker;
-pub use udp_server::UdpServerMocker;
+pub use tcp_server::{TcpMockerOptions, TcpServerMocker};
+pub use udp_server::{UdpMockerOptions, UdpServerMocker};

--- a/src/server_mocker.rs
+++ b/src/server_mocker.rs
@@ -3,7 +3,6 @@
 //! Mock an IP server for testing application that connect to external server.
 
 use std::net::SocketAddr;
-use std::time::Duration;
 
 use crate::{Instruction, ServerMockerError};
 
@@ -15,12 +14,6 @@ use crate::{Instruction, ServerMockerError};
 ///
 /// You can later check that the messages sent by the tested application are the ones expected.
 pub trait ServerMocker {
-    /// Default timeout for the server to wait for a message from the client.
-    const DEFAULT_NET_TIMEOUT: Duration = Duration::from_millis(100);
-
-    /// Timeout if no more instruction is available and [`Instruction::StopExchange`] hasn't been sent
-    const DEFAULT_THREAD_RECEIVER_TIMEOUT: Duration = Duration::from_secs(100);
-
     /// Returns the socket address on which the mock server is listening
     fn socket_address(&self) -> SocketAddr;
 
@@ -41,7 +34,7 @@ pub trait ServerMocker {
     ///
     /// If you push a [`Instruction::SendMessage`] instruction, you must ensure that there is a client connected to the server mocker
     ///
-    /// If you push a [`Instruction::ReceiveMessage`] instruction, you must ensure that the client will send a message to the server mocker within the timeout defined in [`ServerMocker::DEFAULT_NET_TIMEOUT`]
+    /// If you push a [`Instruction::ReceiveMessage`] instruction, you must ensure that the client will send a message to the server mocker within the timeout defined in the options.
     fn add_mock_instructions(
         &self,
         instructions: Vec<Instruction>,
@@ -49,13 +42,13 @@ pub trait ServerMocker {
 
     /// Return first message received by the mock server on the messages queue
     ///
-    /// If no message is available, wait for [`ServerMocker::DEFAULT_NET_TIMEOUT`] and then return None
+    /// If no message is available, wait for `net_timeout` and then return None
     ///
     /// If a message is available, will return the message and remove it from the queue
     fn pop_received_message(&self) -> Option<Vec<u8>>;
 
     /// Return first [error](ServerMockerError) received by the mock server on the errors queue
     ///
-    /// If no error is available, wait for [`ServerMocker::DEFAULT_NET_TIMEOUT`] and then return None
+    /// If no error is available, wait for `net_timeout` and then return None
     fn pop_server_error(&self) -> Option<ServerMockerError>;
 }

--- a/src/tcp_server.rs
+++ b/src/tcp_server.rs
@@ -1,11 +1,8 @@
-//! # `tcp_server_mocker`
-//!
-//! Mock a TCP server for testing application that connect to external TCP server.
-
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
+use std::time::Duration;
 
 use crate::Instruction::{
     self, ReceiveMessageWithMaxSize, SendMessage, SendMessageDependingOnLastReceivedMessage,
@@ -17,12 +14,38 @@ use crate::ServerMockerError::{
     UnableToWriteTcpStream,
 };
 
+// FIXME: consider consolidating options for both TCP & UDP
+/// Options for the TCP server mocker
+#[derive(Debug, Clone)]
+pub struct TcpMockerOptions {
+    /// Socket address on which the server will listen. Will be set to `127.0.0.1:0` by default.
+    pub socket_addr: SocketAddr,
+    /// Timeout for the server to wait for a message from the client.
+    pub net_timeout: Duration,
+    /// Timeout if no more instruction is available and [`Instruction::StopExchange`] hasn't been sent
+    pub rx_timeout: Duration,
+    /// Buffer size for TCP socket
+    pub reader_buffer_size: usize,
+}
+
+impl Default for TcpMockerOptions {
+    fn default() -> Self {
+        Self {
+            socket_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+            net_timeout: Duration::from_millis(100),
+            rx_timeout: Duration::from_secs(100),
+            reader_buffer_size: 1024,
+        }
+    }
+}
+
 /// A TCP server mocker
 ///
 /// Can be used to mock a TCP server if the application you want to test uses TCP sockets to connect to a server.
 ///
 /// Only 1 client can be connected to the mocked server. When the connection is closed, the mocked server will stop.
 pub struct TcpServerMocker {
+    options: TcpMockerOptions,
     socket_addr: SocketAddr,
     instruction_tx: Sender<Vec<Instruction>>,
     message_rx: Receiver<Vec<u8>>,
@@ -38,37 +61,56 @@ impl TcpServerMocker {
 
     /// Create a new instance of the TCP server mocker on the given port.
     /// If the port is already in use, the method will return an error.
+    pub fn new_with_port(port: u16) -> Result<Self, ServerMockerError> {
+        let mut opts = TcpMockerOptions::default();
+        opts.socket_addr.set_port(port);
+        Self::new_with_opts(opts)
+    }
+
+    /// Create a new instance of the TCP server mocker with the given options.
     ///
     /// # Panics
     /// It is assumed that threads can use messages channels without panicking.
-    pub fn new_with_port(port: u16) -> Result<Self, ServerMockerError> {
+    pub fn new_with_opts(options: TcpMockerOptions) -> Result<Self, ServerMockerError> {
         let (instruction_tx, instruction_rx) = mpsc::channel();
         let (message_tx, message_rx) = mpsc::channel();
         let (error_tx, error_rx) = mpsc::channel();
 
-        let addr: SocketAddr = ([127, 0, 0, 1], port).into();
-        let listener = TcpListener::bind(addr).map_err(|e| UnableToBindListener(port, e))?;
-
+        let listener = TcpListener::bind(options.socket_addr)
+            .map_err(|e| UnableToBindListener(options.socket_addr, e))?;
         let socket_addr = listener.local_addr().map_err(UnableToGetLocalAddress)?;
 
-        thread::spawn(move || {
-            let Ok(tcp_stream) = listener.accept().map_err(|e| {
+        let options_copy = options.clone();
+        thread::spawn(move || match listener.accept() {
+            Ok((stream, _addr)) => {
+                TcpServerImpl {
+                    options: options_copy,
+                    stream,
+                    instruction_rx,
+                    message_tx,
+                    error_tx,
+                }
+                .handle_connection();
+            }
+            Err(err) => {
                 error_tx
-                    .send(UnableToAcceptConnection(socket_addr, e))
+                    .send(UnableToAcceptConnection(socket_addr, err))
                     .unwrap();
-            }) else {
-                return;
-            };
-            // We need to manage only 1 client
-            Self::handle_connection(tcp_stream.0, &instruction_rx, &message_tx, &error_tx);
+            }
         });
 
         Ok(Self {
+            options,
             socket_addr,
             instruction_tx,
             message_rx,
             error_rx,
         })
+    }
+
+    /// Get the options used to create the server mocker
+    pub fn options(&self) -> &TcpMockerOptions {
+        &self.options
     }
 }
 
@@ -82,19 +124,19 @@ impl TcpServerMocker {
 /// use socket_server_mocker::Instruction::{self, ReceiveMessage, StopExchange};
 /// use socket_server_mocker::TcpServerMocker;
 ///
-/// let tcp_server_mocker = TcpServerMocker::new_with_port(1234).unwrap();
-/// let mut client = TcpStream::connect("127.0.0.1:1234").unwrap();
+/// let server = TcpServerMocker::new().unwrap();
+/// let mut client = TcpStream::connect(server.socket_address()).unwrap();
 ///
-/// tcp_server_mocker.add_mock_instructions(vec![
+/// server.add_mock_instructions(vec![
 ///     ReceiveMessage,
 ///     StopExchange,
 /// ]).unwrap();
 /// client.write_all(&[1, 2, 3]).unwrap();
 ///
-/// let mock_server_received_message = tcp_server_mocker.pop_received_message();
+/// let mock_server_received_message = server.pop_received_message();
 /// assert_eq!(Some(vec![1, 2, 3]), mock_server_received_message);
-/// assert!(tcp_server_mocker.pop_server_error().is_none());
-/// assert!(tcp_server_mocker.pop_server_error().is_none());
+/// assert!(server.pop_server_error().is_none());
+/// assert!(server.pop_server_error().is_none());
 /// ```
 impl ServerMocker for TcpServerMocker {
     fn socket_address(&self) -> SocketAddr {
@@ -111,42 +153,41 @@ impl ServerMocker for TcpServerMocker {
     }
 
     fn pop_received_message(&self) -> Option<Vec<u8>> {
-        self.message_rx.recv_timeout(Self::DEFAULT_NET_TIMEOUT).ok()
+        self.message_rx.recv_timeout(self.options.net_timeout).ok()
     }
 
     fn pop_server_error(&self) -> Option<ServerMockerError> {
-        self.error_rx.recv_timeout(Self::DEFAULT_NET_TIMEOUT).ok()
+        self.error_rx.recv_timeout(self.options.net_timeout).ok()
     }
 }
 
-/// Specific implementation methods and constants for TCP server mocker
-impl TcpServerMocker {
-    // Default buffer size for TCP socket
-    const DEFAULT_SOCKET_READER_BUFFER_SIZE: usize = 1024;
+/// TCP server mocker thread implementation
+struct TcpServerImpl {
+    options: TcpMockerOptions,
+    stream: TcpStream,
+    instruction_rx: Receiver<Vec<Instruction>>,
+    message_tx: Sender<Vec<u8>>,
+    error_tx: Sender<ServerMockerError>,
+}
 
-    fn handle_connection(
-        mut connection: TcpStream,
-        instruction_rx: &Receiver<Vec<Instruction>>,
-        message_tx: &Sender<Vec<u8>>,
-        error_tx: &Sender<ServerMockerError>,
-    ) {
-        let timeout = Some(Self::DEFAULT_NET_TIMEOUT);
-        if let Err(e) = connection.set_read_timeout(timeout) {
-            error_tx.send(UnableToSetReadTimeout(e)).unwrap();
+/// TCP server mocker thread implementation
+impl TcpServerImpl {
+    fn handle_connection(&mut self) {
+        let timeout = Some(self.options.net_timeout);
+        if let Err(e) = self.stream.set_read_timeout(timeout) {
+            self.error_tx.send(UnableToSetReadTimeout(e)).unwrap();
             return;
         }
         let mut last_received_message: Option<Vec<u8>> = None;
 
         // Timeout: if no more instruction is available and StopExchange hasn't been sent
         // Stop server if no more instruction is available and StopExchange hasn't been sent
-        while let Ok(instructions) =
-            instruction_rx.recv_timeout(Self::DEFAULT_THREAD_RECEIVER_TIMEOUT)
-        {
+        while let Ok(instructions) = self.instruction_rx.recv_timeout(self.options.rx_timeout) {
             for instruction in instructions {
                 match instruction {
                     SendMessage(binary_message) => {
-                        if let Err(e) = Self::send_packet(&mut connection, &binary_message) {
-                            error_tx.send(e).unwrap();
+                        if let Err(e) = self.send_packet(&binary_message) {
+                            self.error_tx.send(e).unwrap();
                         }
                     }
                     SendMessageDependingOnLastReceivedMessage(sent_message_calculator) => {
@@ -155,28 +196,28 @@ impl TcpServerMocker {
                             sent_message_calculator(last_received_message.clone());
                         // Send the message or skip if the closure returned None
                         if let Some(message_to_send) = message_to_send {
-                            if let Err(e) = Self::send_packet(&mut connection, &message_to_send) {
-                                error_tx.send(e).unwrap();
+                            if let Err(e) = self.send_packet(&message_to_send) {
+                                self.error_tx.send(e).unwrap();
                             }
                         }
                     }
                     Instruction::ReceiveMessage => {
-                        match Self::read_packet(&mut connection) {
+                        match self.read_packet() {
                             Ok(whole_received_packet) => {
                                 last_received_message = Some(whole_received_packet.clone());
-                                message_tx.send(whole_received_packet).unwrap();
+                                self.message_tx.send(whole_received_packet).unwrap();
                             }
-                            Err(e) => error_tx.send(e).unwrap(),
+                            Err(e) => self.error_tx.send(e).unwrap(),
                         };
                     }
                     ReceiveMessageWithMaxSize(max_message_size) => {
-                        match Self::read_packet(&mut connection) {
+                        match self.read_packet() {
                             Ok(mut whole_received_packet) => {
                                 whole_received_packet.truncate(max_message_size);
                                 last_received_message = Some(whole_received_packet.clone());
-                                message_tx.send(whole_received_packet).unwrap();
+                                self.message_tx.send(whole_received_packet).unwrap();
                             }
-                            Err(e) => error_tx.send(e).unwrap(),
+                            Err(e) => self.error_tx.send(e).unwrap(),
                         };
                     }
                     Instruction::StopExchange => {
@@ -187,24 +228,28 @@ impl TcpServerMocker {
         }
     }
 
-    // Read a TCP packet from the client, using temporary buffer of size [DEFAULT_SOCKET_READER_BUFFER_SIZE](Self::DEFAULT_SOCKET_READER_BUFFER_SIZE)
-    fn read_packet(tcp_stream: &mut TcpStream) -> Result<Vec<u8>, ServerMockerError> {
+    /// Read a TCP packet from the client, using temporary buffer
+    fn read_packet(&mut self) -> Result<Vec<u8>, ServerMockerError> {
         let mut whole_received_packet: Vec<u8> = Vec::new();
-        let mut buffer = [0; Self::DEFAULT_SOCKET_READER_BUFFER_SIZE];
+        // FIXME: not much point in reading into a buffer and copying, perhaps need to consolidate
+        let mut buffer = vec![0; self.options.reader_buffer_size];
 
         loop {
-            let bytes_read = tcp_stream
+            let bytes_read = self
+                .stream
                 .read(&mut buffer)
                 .map_err(UnableToReadTcpStream)?;
             whole_received_packet.extend_from_slice(&buffer[..bytes_read]);
-            if bytes_read < Self::DEFAULT_SOCKET_READER_BUFFER_SIZE {
+            if bytes_read < self.options.reader_buffer_size {
                 break;
             }
         }
         Ok(whole_received_packet)
     }
 
-    fn send_packet(tcp_stream: &mut TcpStream, packet: &[u8]) -> Result<(), ServerMockerError> {
-        tcp_stream.write_all(packet).map_err(UnableToWriteTcpStream)
+    fn send_packet(&mut self, packet: &[u8]) -> Result<(), ServerMockerError> {
+        self.stream
+            .write_all(packet)
+            .map_err(UnableToWriteTcpStream)
     }
 }

--- a/tests/dns_mock.rs
+++ b/tests/dns_mock.rs
@@ -13,9 +13,9 @@ use trust_dns_client::udp::UdpClientConnection;
 
 #[test]
 fn test_dns_mock() {
-    let dns_server_mocker = UdpServerMocker::new().unwrap();
+    let server = UdpServerMocker::new().unwrap();
 
-    dns_server_mocker
+    server
         .add_mock_instructions(vec![
             // Receive a DNS query
             ReceiveMessageWithMaxSize(512),
@@ -38,10 +38,7 @@ fn test_dns_mock() {
         ])
         .unwrap();
 
-    let address = format!("127.0.0.1:{}", dns_server_mocker.port())
-        .parse()
-        .unwrap();
-    let conn = UdpClientConnection::new(address).unwrap();
+    let conn = UdpClientConnection::new(server.socket_address()).unwrap();
 
     // create the DNS client
     let client = SyncClient::new(conn);
@@ -62,9 +59,9 @@ fn test_dns_mock() {
 
     assert_eq!(
         b"\x01\x00\x00\x01\x00\x00\x00\x00\x00\x01\x03www\x07example\x03com\x00\x00\x01\x00\x01\x00\x00)\x04\xD0\x00\x00\x00\x00\x00\x00",
-        &dns_server_mocker.pop_received_message().unwrap()[2..]
+        &server.pop_received_message().unwrap()[2..]
     );
 
     // Check that no error has been raised by the mocked server
-    assert!(dns_server_mocker.pop_server_error().is_none());
+    assert!(server.pop_server_error().is_none());
 }

--- a/tests/http_reqwest_api_mock.rs
+++ b/tests/http_reqwest_api_mock.rs
@@ -6,9 +6,9 @@ use socket_server_mocker::{ServerMocker, TcpServerMocker};
 #[test]
 fn http_get() {
     // Mock HTTP server on a random free port
-    let http_server_mocker = TcpServerMocker::new().unwrap();
+    let server = TcpServerMocker::new().unwrap();
 
-    http_server_mocker.add_mock_instructions(vec![
+    server.add_mock_instructions(vec![
         // Wait for a HTTP GET request
         ReceiveMessage,
         // Send a HTTP response
@@ -21,7 +21,7 @@ fn http_get() {
     let client = reqwest::blocking::Client::new();
     // Send a HTTP GET request to the mocked server
     let response = client
-        .get(format!("http://localhost:{}/", http_server_mocker.port()))
+        .get(format!("http://localhost:{}/", server.port()))
         .send()
         .unwrap();
 
@@ -34,11 +34,11 @@ fn http_get() {
     assert_eq!(
         format!(
             "GET / HTTP/1.1\r\naccept: */*\r\nhost: localhost:{}\r\n\r\n",
-            http_server_mocker.port()
+            server.port()
         ),
-        from_utf8(&http_server_mocker.pop_received_message().unwrap()).unwrap()
+        from_utf8(&server.pop_received_message().unwrap()).unwrap()
     );
 
     // Check that no error has been raised by the mocked server
-    assert!(http_server_mocker.pop_server_error().is_none());
+    assert!(server.pop_server_error().is_none());
 }

--- a/tests/simple_receiving_tcp_message.rs
+++ b/tests/simple_receiving_tcp_message.rs
@@ -6,17 +6,17 @@ use socket_server_mocker::{ServerMocker, TcpServerMocker};
 
 #[test]
 fn simple_receiving_message_test() {
-    let tcp_server_mocker = TcpServerMocker::new_with_port(1234).unwrap();
-    let mut client = TcpStream::connect("127.0.0.1:1234").unwrap();
+    let server = TcpServerMocker::new_with_port(1234).unwrap();
+    let mut client = TcpStream::connect(server.socket_address()).unwrap();
 
-    tcp_server_mocker
+    server
         .add_mock_instructions(vec![ReceiveMessage, StopExchange])
         .unwrap();
     client.write_all(&[1, 2, 3]).unwrap();
 
-    let mock_server_received_message = tcp_server_mocker.pop_received_message();
+    let mock_server_received_message = server.pop_received_message();
     assert_eq!(Some(vec![1, 2, 3]), mock_server_received_message);
 
     // Check that no error has been raised by the mocked server
-    assert!(tcp_server_mocker.pop_server_error().is_none());
+    assert!(server.pop_server_error().is_none());
 }

--- a/tests/simple_sending_tcp_message.rs
+++ b/tests/simple_sending_tcp_message.rs
@@ -7,13 +7,12 @@ use socket_server_mocker::{ServerMocker, TcpServerMocker};
 #[test]
 fn simple_sending_message_test_random_port() {
     // Use random free port
-    let tcp_server_mocker = TcpServerMocker::new().unwrap();
-    let mock_port = tcp_server_mocker.port();
+    let server = TcpServerMocker::new().unwrap();
 
     // Connect to the mocked server
-    let mut client = TcpStream::connect(format!("127.0.0.1:{mock_port}")).unwrap();
+    let mut client = TcpStream::connect(server.socket_address()).unwrap();
 
-    tcp_server_mocker
+    server
         .add_mock_instructions(vec![
             SendMessage(vec![1, 2, 3]),
             // We accidentally forgot ServerMockerInstruction::StopExchange,
@@ -27,5 +26,5 @@ fn simple_sending_message_test_random_port() {
     assert_eq!([1, 2, 3], buffer[..received_size]);
 
     // Check that no error has been raised by the mocked server
-    assert!(tcp_server_mocker.pop_server_error().is_none());
+    assert!(server.pop_server_error().is_none());
 }


### PR DESCRIPTION
Introduce new structs:
* options struct to hold all configs like timeouts and port
* thread struct to hold the state of the server thread

Removed default timeouts - they are now part of the default options - so must release 0.4.0.

Would it make sense to combine UDP and TCP together into one struct?  I don't see much difference between the two, and they do have the same API except for a few things?