### PR TITLE
Rework API to use just one struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "socket-server-mocker"
 description = "Mock socket server in Rust, for testing various network clients."
 authors = ["Thomas Prévost", "Yuri Astrakhan <YuriAstrakhan>@gmail.com"]
-version = "0.4.0"
+version = "0.5.0"
 rust-version = "1.74.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -22,11 +22,11 @@ lettre = "0.11.9"
 # Forbid unsafe code - we guarantee this crate to be unsafe-free
 unsafe_code = "forbid"
 # The rest of the lints could be overriden in the code
-unused_must_use = "deny"
-missing_docs = "deny"
-unreachable_pub = "deny"
-unused_import_braces = "deny"
-unused_extern_crates = "deny"
+unused_must_use = "warn"
+missing_docs = "warn"
+unreachable_pub = "warn"
+unused_import_braces = "warn"
+unused_extern_crates = "warn"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/README.md
+++ b/README.md
@@ -34,13 +34,12 @@ Here is a simple example in TCP:
 ```rust
 use socket_server_mocker::ServerMocker;
 use socket_server_mocker::Instruction::*;
-use socket_server_mocker::TcpServerMocker;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::str::from_utf8;
 
 // Mock a TCP server listening on port 35642. Note that the mock will only listen on the local interface.
-let server = TcpServerMocker::new_with_port(35642).unwrap();
+let server = ServerMocker::tcp_with_port(35642).unwrap();
 
 // Create the TCP client to test
 let mut client = TcpStream::connect(server.socket_address()).unwrap();
@@ -110,13 +109,13 @@ assert!(server.pop_server_error().is_none());
 Another example in UDP:
 
 ```rust
-use socket_server_mocker::{ServerMocker, UdpServerMocker};
+use socket_server_mocker::ServerMocker;
 use socket_server_mocker::Instruction::{SendMessage, SendMessageDependingOnLastReceivedMessage, ReceiveMessageWithMaxSize};
 use std::net::UdpSocket;
 use std::str::from_utf8;
 
 // Mock a UDP server listening on port 35642. Note that the mock will only listen on the local interface.
-let server = UdpServerMocker::new_with_port(35642).unwrap();
+let server = ServerMocker::udp_with_port(35642).unwrap();
 
 // Create the UDP client to test at a random port
 let client_socket = UdpSocket::bind("127.0.0.1:0").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,9 @@
 //! use std::str::from_utf8;
 //! use socket_server_mocker::ServerMocker;
 //! use socket_server_mocker::Instruction::{ReceiveMessage, SendMessage, StopExchange};
-//! use socket_server_mocker::TcpServerMocker;
 //!
 //! // Mock HTTP server on a random free port
-//! let server = TcpServerMocker::new().unwrap();
+//! let server = ServerMocker::tcp().unwrap();
 //!
 //! server.add_mock_instructions(vec![
 //!   // Wait for an HTTP GET request
@@ -60,5 +59,5 @@ mod udp_server;
 pub use errors::ServerMockerError;
 pub use instructions::Instruction;
 pub use server_mocker::ServerMocker;
-pub use tcp_server::{TcpMockerOptions, TcpServerMocker};
-pub use udp_server::{UdpMockerOptions, UdpServerMocker};
+pub use tcp_server::TcpMocker;
+pub use udp_server::UdpMocker;

--- a/src/server_mocker.rs
+++ b/src/server_mocker.rs
@@ -3,52 +3,174 @@
 //! Mock an IP server for testing application that connect to external server.
 
 use std::net::SocketAddr;
+use std::sync::mpsc;
+use std::sync::mpsc::{Receiver, Sender};
+use std::time::Duration;
 
+use crate::tcp_server::TcpMocker;
+use crate::udp_server::UdpMocker;
+use crate::ServerMockerError::UnableToSendInstructions;
 use crate::{Instruction, ServerMockerError};
 
-/// Trait that define the behavior of a network server mocker over an IP layer.
-///
-/// The mocker is able to receive and send messages to the application that is tested.
-///
-/// The mocker can be configured to send messages to the tested application depending on the messages received.
-///
-/// You can later check that the messages sent by the tested application are the ones expected.
-pub trait ServerMocker {
-    /// Returns the socket address on which the mock server is listening
+/// Options for the mocker, implemented by the specific TCP/UDP backends
+pub trait MockerOptions: Clone {
+    /// Socket address on which the server will listen. Will be set to `127.0.0.1:0` by default.
     fn socket_address(&self) -> SocketAddr;
 
-    /// Returns the port on which the mock server is listening
-    ///
-    /// Listen only on local interface
-    ///
-    /// Port should not be used by another listening process
-    fn port(&self) -> u16 {
-        self.socket_address().port()
+    /// Timeout for the server to wait for a message from the client.
+    fn net_timeout(&self) -> Duration;
+
+    /// Run the server mocker with the given instructions
+    fn run(
+        self,
+        instruction_rx: Receiver<Vec<Instruction>>,
+        message_tx: Sender<Vec<u8>>,
+        error_tx: Sender<ServerMockerError>,
+    ) -> Result<SocketAddr, ServerMockerError>;
+}
+
+/// A socket server mocker, able to mock a TCP or UDP server to help test socket connections in a user app.
+///
+/// # TCP Example
+///
+/// ```
+/// use std::io::Write;
+/// use std::net::TcpStream;
+/// use socket_server_mocker::ServerMocker;
+/// use socket_server_mocker::Instruction::{self, ReceiveMessage, StopExchange};
+///
+/// let server = ServerMocker::tcp().unwrap();
+/// let mut client = TcpStream::connect(server.socket_address()).unwrap();
+///
+/// server.add_mock_instructions(vec![
+///     ReceiveMessage,
+///     StopExchange,
+/// ]).unwrap();
+/// client.write_all(&[1, 2, 3]).unwrap();
+///
+/// let mock_server_received_message = server.pop_received_message();
+/// assert_eq!(Some(vec![1, 2, 3]), mock_server_received_message);
+/// assert!(server.pop_server_error().is_none());
+/// assert!(server.pop_server_error().is_none());
+/// ```
+///
+/// # UDP Example
+///
+/// ```
+/// use std::net::{SocketAddr, UdpSocket};
+/// use socket_server_mocker::ServerMocker;
+/// use socket_server_mocker::Instruction::{ReceiveMessage, SendMessage, StopExchange};
+///
+/// let server = ServerMocker::udp().unwrap();
+/// // 0 = random port
+/// let mut client = UdpSocket::bind("127.0.0.1:0").unwrap();
+/// server.add_mock_instructions(vec![
+///    ReceiveMessage,
+///    SendMessage(vec![4, 5, 6]),
+///    StopExchange,
+/// ]).unwrap();
+///
+/// client.send_to(&[1, 2, 3], server.socket_address()).unwrap();
+/// let mut buffer = [0; 3];
+/// client.recv_from(&mut buffer).unwrap();
+/// assert_eq!([4, 5, 6], buffer);
+/// assert_eq!(Some(vec![1, 2, 3]), server.pop_received_message());
+/// assert!(server.pop_server_error().is_none());
+/// ```
+pub struct ServerMocker<T> {
+    options: T,
+    socket_addr: SocketAddr,
+    instruction_tx: Sender<Vec<Instruction>>,
+    message_rx: Receiver<Vec<u8>>,
+    error_rx: Receiver<ServerMockerError>,
+}
+
+impl ServerMocker<TcpMocker> {
+    /// Create a new instance of the UDP server mocker on a random free port.
+    /// The port can be retrieved with the [`ServerMocker::port`] method.
+    pub fn tcp() -> Result<Self, ServerMockerError> {
+        Self::tcp_with_port(0)
     }
 
-    /// Adds a slice of instructions to the server mocker
-    ///
-    /// The server mocker will execute the instructions in the order they are added
-    ///
-    /// This function could be called as many times as you want, until the connection is closed (event by the client or the server if received a [`Instruction::StopExchange`] instruction)
-    ///
-    /// If you push a [`Instruction::SendMessage`] instruction, you must ensure that there is a client connected to the server mocker
-    ///
-    /// If you push a [`Instruction::ReceiveMessage`] instruction, you must ensure that the client will send a message to the server mocker within the timeout defined in the options.
-    fn add_mock_instructions(
+    /// Create a new instance of the UDP server mocker on the given port.
+    /// If the port is already in use, the method will return an error.
+    pub fn tcp_with_port(port: u16) -> Result<Self, ServerMockerError> {
+        let mut opts = TcpMocker::default();
+        opts.socket_addr.set_port(port);
+        Self::new_with_opts(opts)
+    }
+}
+
+impl ServerMocker<UdpMocker> {
+    /// Create a new instance of the UDP server mocker on a random free port.
+    /// The port can be retrieved with the [`ServerMocker::port`] method.
+    pub fn udp() -> Result<Self, ServerMockerError> {
+        Self::udp_with_port(0)
+    }
+
+    /// Create a new instance of the UDP server mocker on the given port.
+    /// If the port is already in use, the method will return an error.
+    pub fn udp_with_port(port: u16) -> Result<Self, ServerMockerError> {
+        let mut opts = UdpMocker::default();
+        opts.socket_addr.set_port(port);
+        Self::new_with_opts(opts)
+    }
+}
+
+impl<T: MockerOptions> ServerMocker<T> {
+    /// Get the options used to create the server mocker
+    pub fn options(&self) -> &T {
+        &self.options
+    }
+
+    /// Get the socket address on which the server is listening
+    pub fn socket_address(&self) -> SocketAddr {
+        self.socket_addr
+    }
+
+    /// Get the port on which the server is listening
+    pub fn port(&self) -> u16 {
+        self.socket_addr.port()
+    }
+
+    /// Add instructions to the server mocker
+    pub fn add_mock_instructions(
         &self,
         instructions: Vec<Instruction>,
-    ) -> Result<(), ServerMockerError>;
+    ) -> Result<(), ServerMockerError> {
+        self.instruction_tx
+            .send(instructions)
+            .map_err(UnableToSendInstructions)
+    }
 
-    /// Return first message received by the mock server on the messages queue
-    ///
-    /// If no message is available, wait for `net_timeout` and then return None
-    ///
-    /// If a message is available, will return the message and remove it from the queue
-    fn pop_received_message(&self) -> Option<Vec<u8>>;
+    /// Pop the last received message from the server mocker
+    pub fn pop_received_message(&self) -> Option<Vec<u8>> {
+        self.message_rx
+            .recv_timeout(self.options.net_timeout())
+            .ok()
+    }
 
-    /// Return first [error](ServerMockerError) received by the mock server on the errors queue
+    /// Pop the last server error from the server mocker
+    pub fn pop_server_error(&self) -> Option<ServerMockerError> {
+        self.error_rx.recv_timeout(self.options.net_timeout()).ok()
+    }
+
+    /// Create a new instance of the TCP server mocker with the given options.
     ///
-    /// If no error is available, wait for `net_timeout` and then return None
-    fn pop_server_error(&self) -> Option<ServerMockerError>;
+    /// # Panics
+    /// It is assumed that threads can use messages channels without panicking.
+    pub fn new_with_opts(options: T) -> Result<Self, ServerMockerError> {
+        let (instruction_tx, instruction_rx) = mpsc::channel();
+        let (message_tx, message_rx) = mpsc::channel();
+        let (error_tx, error_rx) = mpsc::channel();
+        let socket_addr = options.clone().run(instruction_rx, message_tx, error_tx)?;
+
+        Ok(Self {
+            options,
+            socket_addr,
+            instruction_tx,
+            message_rx,
+            error_rx,
+        })
+    }
 }

--- a/src/udp_server.rs
+++ b/src/udp_server.rs
@@ -1,23 +1,20 @@
 use std::net::{SocketAddr, UdpSocket};
-use std::sync::mpsc;
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
 use std::time::Duration;
 
+use crate::server_mocker::MockerOptions;
 use crate::Instruction::{
     self, ReceiveMessageWithMaxSize, SendMessage, SendMessageDependingOnLastReceivedMessage,
 };
-use crate::ServerMocker;
 use crate::ServerMockerError::{
     self, FailedToSendUdpMessage, GotSendMessageBeforeReceiveMessage, UnableToBindListener,
-    UnableToGetLocalAddress, UnableToReadUdpStream, UnableToSendInstructions,
-    UnableToSetReadTimeout,
+    UnableToGetLocalAddress, UnableToReadUdpStream, UnableToSetReadTimeout,
 };
 
-// FIXME: consider combining Udp and Tcp options into a single struct
-/// Options for the TCP server mocker
+/// Options for the UDP server mocker
 #[derive(Debug, Clone)]
-pub struct UdpMockerOptions {
+pub struct UdpMocker {
     /// Socket address on which the server will listen. Will be set to `127.0.0.1:0` by default.
     pub socket_addr: SocketAddr,
     /// Timeout for the server to wait for a message from the client.
@@ -28,138 +25,54 @@ pub struct UdpMockerOptions {
     pub max_packet_size: usize,
 }
 
-impl Default for UdpMockerOptions {
+impl Default for UdpMocker {
     fn default() -> Self {
         Self {
             socket_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
             net_timeout: Duration::from_millis(100),
-            rx_timeout: Duration::from_secs(100),
+            rx_timeout: Duration::from_millis(100),
             max_packet_size: 65507,
         }
     }
 }
 
-/// A UDP server mocker
-///
-/// Can be used to mock a UDP server if the application you want to test uses UDP sockets to connect to a server.
-///
-/// It's preferable that only 1 client sends messages to the mocked server.
-/// When the object is dropped or a [stop instruction](Instruction::StopExchange) is received, the mocked server will stop.
-/// The server will also stop in case no more instructions are available.
-pub struct UdpServerMocker {
-    options: UdpMockerOptions,
-    socket_addr: SocketAddr,
-    instruction_tx: Sender<Vec<Instruction>>,
-    message_rx: Receiver<Vec<u8>>,
-    error_rx: Receiver<ServerMockerError>,
-}
-
-impl UdpServerMocker {
-    /// Create a new instance of the UDP server mocker on a random free port.
-    /// The port can be retrieved with the [`ServerMocker::port`] method.
-    pub fn new() -> Result<Self, ServerMockerError> {
-        Self::new_with_port(0)
-    }
-
-    /// Create a new instance of the UDP server mocker on the given port.
-    /// If the port is already in use, the method will return an error.
-    pub fn new_with_port(port: u16) -> Result<Self, ServerMockerError> {
-        let mut opts = UdpMockerOptions::default();
-        opts.socket_addr.set_port(port);
-        Self::new_with_opts(opts)
-    }
-
-    /// Create a new instance of the TCP server mocker with the given options.
-    ///
-    /// # Panics
-    /// It is assumed that threads can use messages channels without panicking.
-    pub fn new_with_opts(options: UdpMockerOptions) -> Result<Self, ServerMockerError> {
-        let (instruction_tx, instruction_rx) = mpsc::channel();
-        let (message_tx, message_rx) = mpsc::channel();
-        let (error_tx, error_rx) = mpsc::channel();
-
-        let listener = UdpSocket::bind(options.socket_addr)
-            .map_err(|e| UnableToBindListener(options.socket_addr, e))?;
-        let socket_addr = listener.local_addr().map_err(UnableToGetLocalAddress)?;
-
-        let options_copy = options.clone();
-        thread::spawn(move || {
-            UdpServerImpl {
-                options: options_copy,
-                connection: listener,
-                instruction_rx,
-                message_tx,
-                error_tx,
-            }
-            .handle_dgram_stream();
-        });
-
-        Ok(Self {
-            options,
-            socket_addr,
-            instruction_tx,
-            message_rx,
-            error_rx,
-        })
-    }
-
-    /// Get the options used to create the server mocker
-    pub fn options(&self) -> &UdpMockerOptions {
-        &self.options
-    }
-}
-
-/// `UdpServerMocker` implementation
-///
-/// # Example
-/// ```
-/// use std::net::{SocketAddr, UdpSocket};
-/// use socket_server_mocker::ServerMocker;
-/// use socket_server_mocker::Instruction::{ReceiveMessage, SendMessage, StopExchange};
-/// use socket_server_mocker::UdpServerMocker;
-///
-/// let server = UdpServerMocker::new().unwrap();
-/// // 0 = random port
-/// let mut client = UdpSocket::bind("127.0.0.1:0").unwrap();
-/// server.add_mock_instructions(vec![
-///    ReceiveMessage,
-///    SendMessage(vec![4, 5, 6]),
-///    StopExchange,
-/// ]).unwrap();
-///
-/// client.send_to(&[1, 2, 3], server.socket_address()).unwrap();
-/// let mut buffer = [0; 3];
-/// client.recv_from(&mut buffer).unwrap();
-/// assert_eq!([4, 5, 6], buffer);
-/// assert_eq!(Some(vec![1, 2, 3]), server.pop_received_message());
-/// assert!(server.pop_server_error().is_none());
-/// ```
-impl ServerMocker for UdpServerMocker {
+impl MockerOptions for UdpMocker {
     fn socket_address(&self) -> SocketAddr {
         self.socket_addr
     }
 
-    fn add_mock_instructions(
-        &self,
-        instructions: Vec<Instruction>,
-    ) -> Result<(), ServerMockerError> {
-        self.instruction_tx
-            .send(instructions)
-            .map_err(UnableToSendInstructions)
+    fn net_timeout(&self) -> Duration {
+        self.net_timeout
     }
 
-    fn pop_received_message(&self) -> Option<Vec<u8>> {
-        self.message_rx.recv_timeout(self.options.net_timeout).ok()
-    }
+    fn run(
+        self,
+        instruction_rx: Receiver<Vec<Instruction>>,
+        message_tx: Sender<Vec<u8>>,
+        error_tx: Sender<ServerMockerError>,
+    ) -> Result<SocketAddr, ServerMockerError> {
+        let connection = UdpSocket::bind(self.socket_addr)
+            .map_err(|e| UnableToBindListener(self.socket_addr, e))?;
+        let socket_addr = connection.local_addr().map_err(UnableToGetLocalAddress)?;
 
-    fn pop_server_error(&self) -> Option<ServerMockerError> {
-        self.error_rx.recv_timeout(self.options.net_timeout).ok()
+        thread::spawn(move || {
+            UdpServerImpl {
+                options: self,
+                connection,
+                instruction_rx,
+                message_tx,
+                error_tx,
+            }
+            .run();
+        });
+
+        Ok(socket_addr)
     }
 }
 
 /// TCP server mocker thread implementation
 struct UdpServerImpl {
-    options: UdpMockerOptions,
+    options: UdpMocker,
     connection: UdpSocket,
     instruction_rx: Receiver<Vec<Instruction>>,
     message_tx: Sender<Vec<u8>>,
@@ -168,7 +81,7 @@ struct UdpServerImpl {
 
 /// Specific implementation methods and constants for UDP server mocker
 impl UdpServerImpl {
-    fn handle_dgram_stream(&self) {
+    fn run(&self) {
         let timeout = Some(self.options.net_timeout);
         if let Err(e) = self.connection.set_read_timeout(timeout) {
             self.error_tx.send(UnableToSetReadTimeout(e)).unwrap();

--- a/tests/dns_mock.rs
+++ b/tests/dns_mock.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use socket_server_mocker::Instruction::{
     ReceiveMessageWithMaxSize, SendMessageDependingOnLastReceivedMessage, StopExchange,
 };
-use socket_server_mocker::{ServerMocker, UdpServerMocker};
+use socket_server_mocker::ServerMocker;
 use trust_dns_client::client::{Client, SyncClient};
 use trust_dns_client::op::DnsResponse;
 use trust_dns_client::rr::rdata::A;
@@ -13,7 +13,7 @@ use trust_dns_client::udp::UdpClientConnection;
 
 #[test]
 fn test_dns_mock() {
-    let server = UdpServerMocker::new().unwrap();
+    let server = ServerMocker::udp().unwrap();
 
     server
         .add_mock_instructions(vec![

--- a/tests/http_reqwest_api_mock.rs
+++ b/tests/http_reqwest_api_mock.rs
@@ -1,12 +1,12 @@
 use std::str::from_utf8;
 
 use socket_server_mocker::Instruction::{ReceiveMessage, SendMessage, StopExchange};
-use socket_server_mocker::{ServerMocker, TcpServerMocker};
+use socket_server_mocker::ServerMocker;
 
 #[test]
 fn http_get() {
     // Mock HTTP server on a random free port
-    let server = TcpServerMocker::new().unwrap();
+    let server = ServerMocker::tcp().unwrap();
 
     server.add_mock_instructions(vec![
         // Wait for a HTTP GET request

--- a/tests/simple_receiving_tcp_message.rs
+++ b/tests/simple_receiving_tcp_message.rs
@@ -2,11 +2,11 @@ use std::io::Write;
 use std::net::TcpStream;
 
 use socket_server_mocker::Instruction::{ReceiveMessage, StopExchange};
-use socket_server_mocker::{ServerMocker, TcpServerMocker};
+use socket_server_mocker::ServerMocker;
 
 #[test]
 fn simple_receiving_message_test() {
-    let server = TcpServerMocker::new_with_port(1234).unwrap();
+    let server = ServerMocker::tcp_with_port(1234).unwrap();
     let mut client = TcpStream::connect(server.socket_address()).unwrap();
 
     server

--- a/tests/simple_sending_tcp_message.rs
+++ b/tests/simple_sending_tcp_message.rs
@@ -2,12 +2,12 @@ use std::io::Read;
 use std::net::TcpStream;
 
 use socket_server_mocker::Instruction::SendMessage;
-use socket_server_mocker::{ServerMocker, TcpServerMocker};
+use socket_server_mocker::ServerMocker;
 
 #[test]
 fn simple_sending_message_test_random_port() {
     // Use random free port
-    let server = TcpServerMocker::new().unwrap();
+    let server = ServerMocker::tcp().unwrap();
 
     // Connect to the mocked server
     let mut client = TcpStream::connect(server.socket_address()).unwrap();

--- a/tests/smtp_mock.rs
+++ b/tests/smtp_mock.rs
@@ -3,12 +3,12 @@ use std::time::Duration;
 use lettre::transport::smtp::client::Tls;
 use lettre::{Message, SmtpTransport, Transport};
 use socket_server_mocker::Instruction::{ReceiveMessage, SendMessage, StopExchange};
-use socket_server_mocker::{ServerMocker, TcpServerMocker};
+use socket_server_mocker::ServerMocker;
 
 #[test]
 fn test_smtp_mock() {
     // Create an SMTP TCP server mocker listening on port 2525 (SMTP default port is 25)
-    let server = TcpServerMocker::new_with_port(2525).unwrap();
+    let server = ServerMocker::tcp_with_port(2525).unwrap();
 
     // Mocked server behavior
     server.add_mock_instructions(vec![


### PR DESCRIPTION
Fixes #17

* Now all mock socket instantiations are done with a specific object:

```rust
// protocol-specific functions
ServerMocker::tcp()
ServerMocker::tcp_with_port(port)
ServerMocker::udp()
ServerMocker::udp_with_port(port)
// generic function taking anything that
// implements the needed (non-public) trait
ServerMocker::new_with_opts(options_object)
```

* Fix timeouts - by accident they had 100s instead of 100ms
* Improve PostgreSQL tests with explicit configurations + timeouts + explicit communication stop (to prevent long waits when the client was shutting down)